### PR TITLE
Do not raise an exception on a faulty Auth Header

### DIFF
--- a/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
+++ b/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
@@ -47,11 +47,11 @@ class OauthPermissionReader implements OauthPermissionReaderInterface
         $request = Request::createFromGlobals();
         $authorizationToken = $request->headers->get(OauthPermissionConfig::HEADER_AUTHORIZATION);
 
-        if (!$authorizationToken) {
+        $accessToken = $this->extractToken($authorizationToken);
+
+        if (!$accessToken) {
             return new PermissionCollectionTransfer();
         }
-
-        [$type, $accessToken] = $this->extractToken($authorizationToken);
 
         $oauthAccessTokenDataTransfer = $this->oauthService->extractAccessTokenData($accessToken);
 
@@ -85,10 +85,16 @@ class OauthPermissionReader implements OauthPermissionReaderInterface
     /**
      * @param string $authorizationToken
      *
-     * @return array
+     * @return string
      */
-    protected function extractToken(string $authorizationToken): array
+    protected function extractToken(string $authorizationToken): ?string
     {
-        return preg_split('/\s+/', $authorizationToken);
+        $split = preg_split('/\s+/', $authorizationToken);
+
+        if (empty($split[1])) {
+            return null;
+        }
+
+        return $split[1];
     }
 }

--- a/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
+++ b/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
@@ -85,10 +85,14 @@ class OauthPermissionReader implements OauthPermissionReaderInterface
     /**
      * @param string $authorizationToken
      *
-     * @return string
+     * @return string|null
      */
-    protected function extractToken(string $authorizationToken): ?string
+    protected function extractToken(?string $authorizationToken): ?string
     {
+        if (empty($authorizationToken)) {
+            return null;
+        }
+
         $split = preg_split('/\s+/', $authorizationToken);
 
         if (empty($split[1])) {

--- a/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
+++ b/src/Spryker/Client/OauthPermission/OauthPermission/OauthPermissionReader.php
@@ -83,7 +83,7 @@ class OauthPermissionReader implements OauthPermissionReaderInterface
     }
 
     /**
-     * @param string $authorizationToken
+     * @param string|null $authorizationToken
      *
      * @return string|null
      */


### PR DESCRIPTION
## PR Description

Currently if the token read from the header contains no spaces there will be an exception.
But this should only mean that you can't authorize with this header.
So I now check if the preg_split is successful and if no we just retun an empty
Permission Collection Transfer in the end.


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
